### PR TITLE
IPC ou sinteticos podem ser construidos na robotica

### DIFF
--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -2,7 +2,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 
 /obj/item/mmi/posibrain
 	name = "positronic brain"
-	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves."
+	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves.<br>Can be transformed into an IPC brain with <b>Alt+Click</b>!"
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "posibrain"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -196,3 +196,27 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 
 /obj/item/mmi/posibrain/add_mmi_overlay()
 	return
+
+
+/obj/item/mmi/posibrain/AltClick(mob/user)
+	if(!brainmob?.mind || !brainmob)
+		to_chat(user, span_notice("You press the button and release it, but nothing happens because the positronic brain is inactive."))
+		return
+	to_ipc_posi(user)
+	to_chat(user, span_notice("You press the button to transform the positronic brain into an IPC brain."))
+
+/obj/item/mmi/posibrain/proc/to_ipc_posi(mob/user)
+	var/obj/item/organ/brain/ipc/brain = new /obj/item/organ/brain/ipc
+	brainmob.container = null //Reset brainmob mmi var.
+	brainmob.forceMove(brain) //Throw mob into brain.
+	brainmob.set_stat(DEAD)
+	brainmob.emp_damage = 0
+	brainmob.reset_perspective() //so the brainmob follows the brain organ instead of the mmi. And to update our vision
+	brain.brainmob = brainmob //Set the brain to use the brainmob
+	brainmob = null //Set mmi brainmob var to null
+	src.forceMove(drop_location())
+	if(Adjacent(user))
+		user.put_in_hands(brain)
+	brain.organ_flags &= ~ORGAN_FROZEN
+	brain = null //No more brain in here
+	qdel(src)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1178,6 +1178,52 @@ Mark this mob, then navigate to the preferences of the client you desire and cal
 /mob/living/carbon/human/species/ipc
 	race = /datum/species/ipc
 
+/mob/living/carbon/human/species/ipc_empty
+	parent_type = /mob/living/carbon/human/species/ipc
+
+	// Override New() to remove organs and limbs
+	New()
+		..()
+		// Remove all organs
+		for (var/obj/item/organ/O in internal_organs)
+			qdel(O)
+
+		// Remove all limbs
+		for (var/obj/item/bodypart/L in bodyparts)
+			if (L.body_part == CHEST)
+				continue
+			qdel(L)
+
+		hair_style = "Bald"
+		facial_hair_style = "Shaved"
+		update_hair()
+		update_body()
+		set_stat(DEAD)
+		timeofdeath = world.time + 99999999999999999999
+
+/mob/living/carbon/human/species/synth_empty
+	parent_type = /mob/living/carbon/human/species/synth
+
+	// Override New() to remove organs and limbs
+	New()
+		..()
+		// Remove all organs
+		for (var/obj/item/organ/O in internal_organs)
+			qdel(O)
+
+		// Remove all limbs
+		for (var/obj/item/bodypart/L in bodyparts)
+			if (L.body_part == CHEST)
+				continue
+			qdel(L)
+
+		hair_style = "Bald"
+		facial_hair_style = "Shaved"
+		update_hair()
+		update_body()
+		set_stat(DEAD)
+		timeofdeath = world.time + 99999999999999999999
+
 /mob/living/carbon/human/species/roundstartslime
 	race = /datum/species/jelly/roundstartslime
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1199,7 +1199,7 @@ Mark this mob, then navigate to the preferences of the client you desire and cal
 		update_hair()
 		update_body()
 		set_stat(DEAD)
-		timeofdeath = world.time + 99999999999999999999
+		timeofdeath = world.time + 100000000000000000000
 
 /mob/living/carbon/human/species/synth_empty
 	parent_type = /mob/living/carbon/human/species/synth
@@ -1222,7 +1222,7 @@ Mark this mob, then navigate to the preferences of the client you desire and cal
 		update_hair()
 		update_body()
 		set_stat(DEAD)
-		timeofdeath = world.time + 99999999999999999999
+		timeofdeath = world.time + 100000000000000000000
 
 /mob/living/carbon/human/species/roundstartslime
 	race = /datum/species/jelly/roundstartslime

--- a/modular_splurt/code/modules/research/designs/mechfabricator_designs.dm
+++ b/modular_splurt/code/modules/research/designs/mechfabricator_designs.dm
@@ -190,12 +190,22 @@
 	build_path = /obj/item/organ/tongue/robot/ipc
 	category = list("IPC Organs")
 
-/datum/design/ipc_brain
-	name = "IPC Brain (inert)"
-	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. It has an IPC serial number engraved on the top. It is usually slotted into the head of synthetic crewmembers."
-	id = "ipc_brain"
+/datum/design/ipc_body
+	name = "IPC Body"
+	desc = "An IPC body made of metal. Now you can create your own IPC. Must be completed with other IPC parts."
+	id = "ipc_body"
 	build_type = MECHFAB
-	construction_time = 40
-	materials = list(/datum/material/iron = 1000, /datum/material/glass = 300, /datum/material/silver = 500, /datum/material/gold = 400)
-	build_path = /obj/item/organ/brain/ipc
+	construction_time = 200
+	materials = list(/datum/material/iron = 20000, /datum/material/glass = 1000, /datum/material/silver = 200, /datum/material/gold = 400)
+	build_path = /mob/living/carbon/human/species/ipc_empty
+	category = list("IPC Organs")
+
+/datum/design/synth_body
+	name = "Synth Body"
+	desc = "A Synth body. Now you can create your own live synth. Must be completed with other synth parts."
+	id = "synth_body"
+	build_type = MECHFAB
+	construction_time = 200
+	materials = list(/datum/material/iron = 20000, /datum/material/glass = 1000, /datum/material/silver = 200, /datum/material/gold = 400)
+	build_path = /mob/living/carbon/human/species/synth_empty
 	category = list("IPC Organs")

--- a/modular_splurt/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/modular_splurt/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -16,8 +16,9 @@
 		"ipc_eyes",
 		"ipc_ears",
 		"ipc_tongue",
-		"ipc_brain",
-		"ci-power-cord"
+		"ci-power-cord",
+		"ipc_body",
+		"synth_body"
 	)
 	LAZYADD(design_ids, extra_designs)
 	. = ..()


### PR DESCRIPTION
# Sobre o Pull Request
Os corpos do IPC e sinteticos podem ser construídos no Exosuit Fabricator, e o positronic brain pode ser transformado em um cérebro do IPC para caber nos corpos do IPC.

## Porque Seria Bom Para O Jogo
Quando um player morre as vezes seu corpo nao é achado, e com a posibilidade de criar IPCs tras a possibilidade de voltarem ao jogo sem ter que vocltar apenas como Cyborgs.
E tambem é bem divertido passar o tempo construindo eles.

## Pre-Merge Teste
Eu já testei as modificações diversas vezes e parece estar perfeitinho.

## Changelog
add: a possibilidade de transformar o positronic brain para o IPC brain usando Alt+Click nele mesmo(apenas quando estiver ativo/possuido).
add: corpos de IPCs e sinteticos podem ser construidos na Exosuit Fabricator.